### PR TITLE
Fix ADC configuration

### DIFF
--- a/boards/arm/zest_core_stm32l4a6rg/zest_core_stm32l4a6rg.dts
+++ b/boards/arm/zest_core_stm32l4a6rg/zest_core_stm32l4a6rg.dts
@@ -120,6 +120,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pc2 &adc1_in4_pc3 &adc1_in5_pa0 &adc1_in6_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Since Zephyr 3.5.0 `adc-clock-source` and `adc-prescaler` the parameters must be added.

https://docs.zephyrproject.org/latest/build/dts/api/bindings/adc/st%2Cstm32-adc.html#std-dtcompatible-st-stm32-adc