### PR TITLE
Fixed Input Event compile issue

### DIFF
--- a/boards/catie/zest_core_stm32l4a6rg/zest_core_stm32l4a6rg.dts
+++ b/boards/catie/zest_core_stm32l4a6rg/zest_core_stm32l4a6rg.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/l4/stm32l4a6Xg.dtsi>
 #include <st/l4/stm32l4a6rgtx-pinctrl.dtsi>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "sixtron_connector.dtsi"
 
 / {
@@ -33,6 +34,7 @@
 		user_button: button {
 			label = "User Button";
 			gpios = <&gpioh 3 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_BTN_0>;
 		};
 	};
 


### PR DESCRIPTION
Usage for Input Event presented in [zephyr_input-event_example](https://github.com/catie-aq/zephyr_input-event_example).

Input Event system replace the need for interrupt and gpio interuption configuration
```C
static void button_event_callback(struct input_event *evt)
{
    printf("Event! [0x%02X][0x%02X][0x%04X][0x%08X]\n",
            evt->sync,
            evt->type,
            evt->code,
            evt->value);
    if (evt->code == INPUT_BTN_0) {
        if (evt->value == 1) {
            printf("Button pressed!\n");
        } else {
            printf("Button released!\n");
        }
    }
}

INPUT_CALLBACK_DEFINE(NULL, button_event_callback);
```