### PR TITLE
47 rework pwm definition to use nexus mapping

### DIFF
--- a/boards/catie/zest_core_stm32l4a6rg/sixtron_connector.dtsi
+++ b/boards/catie/zest_core_stm32l4a6rg/sixtron_connector.dtsi
@@ -54,18 +54,14 @@
                    <DIO20 0 &gpiob 9 0>;
     };
 
-    sixtron_connector_1_pwms: sixtron-connector-1-pwms {
-    	compatible = "pwm-leds";
-
-    	sixtron_connector_1_pwm1: pwm-1 {
-    		pwms = <&pwm1 3 1000000 PWM_POLARITY_NORMAL>;
-    	};
-    	sixtron_connector_1_pwm2: pwm-2 {
-    		pwms = <&pwm1 2 1000000 PWM_POLARITY_NORMAL>;
-    	};
-    	sixtron_connector_1_pwm3: pwm-3 {
-    		pwms = <&pwm3 3 1000000 PWM_POLARITY_NORMAL>;
-    	};
+    sixtron_connector_1_pwm: sixtron-connector-1-pwm {
+        compatible = "sixtron-pwm";
+        #pwm-cells = <3>;
+        pwm-map-mask = <0xffffffff 0x0 0x0>;
+        pwm-map-pass-thru = <0x0 0xffffffff 0x0f>;
+        pwm-map = <PWM1 0 0 &pwm1 3 0 0>,	/* PWM1 = */
+                  <PWM2 0 0 &pwm1 2 0 0>,	/* PWM2 = */
+                  <PWM3 0 0 &pwm3 3 0 0>;	/* PWM3 = */
     };
 
     sixtron_connector_1_adc: sixtron-connector-1-adc {
@@ -87,9 +83,7 @@ sixtron_i2c: &sixtron_connector_1_i2c {};
 sixtron_uart: &sixtron_connector_1_uart {};
 sixtron_spi: &sixtron_connector_1_spi {};
 sixtron_dac: &sixtron_connector_1_dac {};
-sixtron_pwm1: &sixtron_connector_1_pwm1 {};
-sixtron_pwm2: &sixtron_connector_1_pwm2 {};
-sixtron_pwm3: &sixtron_connector_1_pwm3 {};
+sixtron_pwm: &sixtron_connector_1_pwm {};
 sixtron_adc: &sixtron_connector_1_adc {};
 
 sixtron_connector: &sixtron_connector_1 {};

--- a/boards/catie/zest_core_stm32l4a6rg/sixtron_connector.dtsi
+++ b/boards/catie/zest_core_stm32l4a6rg/sixtron_connector.dtsi
@@ -59,9 +59,9 @@
         #pwm-cells = <3>;
         pwm-map-mask = <0xffffffff 0x0 0x0>;
         pwm-map-pass-thru = <0x0 0xffffffff 0x0f>;
-        pwm-map = <PWM1 0 0 &pwm1 3 0 0>,	/* PWM1 = */
-                  <PWM2 0 0 &pwm1 2 0 0>,	/* PWM2 = */
-                  <PWM3 0 0 &pwm3 3 0 0>;	/* PWM3 = */
+        pwm-map = <PWM1 0 0 &pwm1 3 0 0>,
+                  <PWM2 0 0 &pwm1 2 0 0>,
+                  <PWM3 0 0 &pwm3 3 0 0>;
     };
 
     sixtron_connector_1_adc: sixtron-connector-1-adc {


### PR DESCRIPTION
Allow the user to define PWM thanks to `zephyr,user` in `app.overlay`:

```
#include <zephyr/dt-bindings/gpio/sixtron-header.h>

/ {
    zephyr,user {
        /* Adjust channel number according to pinmux in board.dts */
        pwms = <&sixtron_pwm PWM1 1000000 PWM_POLARITY_NORMAL>,
               <&sixtron_pwm PWM2 1000000 PWM_POLARITY_NORMAL>,
               <&sixtron_pwm PWM3 1000000 PWM_POLARITY_NORMAL>;
	};
};
```

Then use the PWM example presented in [zephyr_pwm_example](https://github.com/catie-aq/zephyr_pwm_example).

PWM can be accessed individually like following:

```C
#define INDEX 0 /* Index for PWM1 defined in app.overlay */
static const struct pwm_dt_spec pwm_dev =
            PWM_DT_SPEC_GET_BY_IDX(DT_PATH(zephyr_user), INDEX);
```
Or as an array:

```C
#if !DT_NODE_EXISTS(DT_PATH(zephyr_user)) || \
	!DT_NODE_HAS_PROP(DT_PATH(zephyr_user), pwms)
#error "No suitable devicetree overlay specified"
#endif

#define DT_SPEC_AND_COMMA(node_id, prop, idx) \
	PWM_DT_SPEC_GET_BY_IDX(node_id, idx),

/* Data of PWMs pwms specified in devicetree. */
static const struct pwm_dt_spec pwm_specs[] = {
	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), pwms,
			     DT_SPEC_AND_COMMA)
};
```

> [!Caution]
> Require #46 to be merge first.