### PR TITLE
Set  timers1 and timers3 prescaler for 1 kHz PWM  frequency

### DIFF
--- a/boards/catie/zest_core_stm32l4a6rg/zest_core_stm32l4a6rg.dts
+++ b/boards/catie/zest_core_stm32l4a6rg/zest_core_stm32l4a6rg.dts
@@ -94,7 +94,7 @@
 };
 
 &timers1 {
-	st,prescaler = <1000>;
+	st,prescaler = <1>;
 	status = "okay";
 
 	pwm1: pwm {
@@ -105,7 +105,7 @@
 };
 
 &timers3 {
-	st,prescaler = <1000>;
+	st,prescaler = <1>;
 	status = "okay";
 
 	pwm3: pwm {


### PR DESCRIPTION
Prescaler calculation for timers1 and timers3 

- Fpwm_min: 1 kHz 
- Fclock_max : 80Mhz ref to zest_core_stm32l4a6rg.dts
- Resoltion : 16bits

Prescaler=  {Fclock_max/(Fpwm_min×Resolution) } −1

Prescaler ≈1 (rounded up to the nearest integer).

