### PR TITLE
Fix DIO6 GPIO pin mapping

### DIFF
--- a/boards/catie/zest_core_stm32l4a6rg/sixtron_connector.dtsi
+++ b/boards/catie/zest_core_stm32l4a6rg/sixtron_connector.dtsi
@@ -37,7 +37,7 @@
                    <DIO3 0 &gpiod 2 0>,
                    <DIO4 0 &gpioc 12 0>,
                    <DIO5 0 &gpioa 8 0>,
-                   <DIO6 0 &gpioc 1 0>,
+                   <DIO6 0 &gpioc 10 0>,
                    <DIO7 0 &gpioa 6 0>,
                    <DIO8 0 &gpioa 7 0>,
                    <DIO9 0 &gpioa 4 0>,


### PR DESCRIPTION
This pull request makes a small change to the `sixtron_connector.dtsi` device tree file, updating the pin assignment for `DIO6` to use pin 10 on GPIOC instead of pin 1.

* Changed `DIO6` mapping from `&gpioc 1` to `&gpioc 10` in `sixtron_connector.dtsi` to correct the pin assignment.